### PR TITLE
Fix error when trying to get ministry content for something without a ministry

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -112,6 +112,9 @@ class dataSource extends ContentItem.dataSource {
 
   getByMinistry = async (ministry) => {
     // get the Rock enum value (DefinedValue)
+    if (!ministry) {
+      return [];
+    }
     const { guid } = await this.request('DefinedValues')
       // 117 is the Ministries defined type
       .filter(`DefinedTypeId eq 117 and Value eq '${ministry}'`)


### PR DESCRIPTION
Fixes this crash: https://longhollow-web.vercel.app/connect/ca4cf9c76a70ec7ef648faedaf836bac

**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**
