### PR TITLE
feat: add trackPageView mutation

### DIFF
--- a/apollos-church-api/src/data/index.js
+++ b/apollos-church-api/src/data/index.js
@@ -16,7 +16,7 @@ import * as Cache from '@apollosproject/data-connector-redis-cache';
 import * as Sms from '@apollosproject/data-connector-twilio';
 import {
   Followings,
-  Interactions,
+  // Interactions,
   RockConstants,
   // ContentItem,
   ContentChannel,
@@ -57,6 +57,7 @@ import * as Person from './Person';
 import * as Matrix from './Matrix';
 import * as Search from './Algolia';
 import * as LiveStream from './LiveStream';
+import * as Interactions from './interactions';
 
 // This module is used to attach Rock User updating to the OneSignal module.
 // This module includes a Resolver that overides a resolver defined in `OneSignal`

--- a/apollos-church-api/src/data/interactions/index.js
+++ b/apollos-church-api/src/data/interactions/index.js
@@ -1,0 +1,54 @@
+import { Interactions } from '@apollosproject/data-connector-rock';
+import gql from 'graphql-tag';
+
+export class dataSource extends Interactions.dataSource {
+  async createPageViewInteraction({ pageTitle, pageUrl }) {
+    const {
+      dataSources: { RockConstants, Auth },
+    } = this.context;
+
+    const interactionComponent = await RockConstants.createOrFindInteractionComponent(
+      {
+        componentName: pageTitle,
+        channelId: 3, // ExternalWebsite
+        entityId: null,
+      }
+    );
+
+    const currentUser = await Auth.getCurrentPerson();
+
+    await this.post('/Interactions', {
+      PersonAliasId: currentUser.primaryAliasId,
+      InteractionComponentId: interactionComponent.id,
+      Operation: 'View',
+      InteractionDateTime: new Date().toJSON(),
+      InteractionSummary: pageTitle,
+      InteractionData: pageUrl,
+      // We can introduce the session variable if the client asks for it.
+      // I ran into some problems with stale sessions causing this request to fail
+      // So I figured it would be better to default this to off.
+      // InteractionSessionId: this.context.sessionId,
+    });
+
+    return {
+      success: true,
+    };
+  }
+}
+
+export const schema = gql`
+  ${Interactions.schema}
+
+  extend type Mutation {
+    trackPageView(pageUrl: String!, pageTitle: String!): InteractionResult
+  }
+`;
+
+export const resolver = {
+  ...Interactions.resolver,
+  Mutation: {
+    ...Interactions.resolver.mutation,
+    trackPageView: (root, args, { dataSources }) =>
+      dataSources.Interactions.createPageViewInteraction(args),
+  },
+};


### PR DESCRIPTION
**IMPORTANT: If this is for testing code in our npm dependencies, you should be pointing your PR at the `canary` or `next` branch. `master` should never rely on unreleased code.**

Run this while logged in. 

```
mutation pageView {
  trackPageView(pageUrl:"https://longhollow.org/test2", pageTitle:"pageViewTest") {
    success
  }
}
```

Following that, check your website visits badge on your Rock profile, make sure you last visit was "today" 

<img width="680" alt="Screen Shot 2021-04-26 at 11 52 20 AM" src="https://user-images.githubusercontent.com/1637694/116115560-76926200-a688-11eb-8c28-05e489e52c99.png">
