### PR TITLE
feat: new filtered home tab algo

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -191,7 +191,7 @@ TABS:
             - 35
       type: VerticalCardList
     - algorithms:
-        - type: NON_PERSONA_CONTENT_FEED
+        - type: NON_PERSONA_OR_FEATURED_CONTENT_FEED
           arguments:
             channelIds:
               - 36

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -191,7 +191,7 @@ TABS:
             - 35
       type: VerticalCardList
     - algorithms:
-        - type: CONTENT_FEED
+        - type: NON_PERSONA_CONTENT_FEED
           arguments:
             channelIds:
               - 36

--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -7,7 +7,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     HOME_TAB_CONTENT_FEED: this.homeTabContentFeedAlgorithm.bind(this),
-    NON_PERSONA_CONTENT_FEED: this.nonPersonaContentFeedAlgorithm.bind(this),
+    NON_PERSONA_OR_FEATURED_CONTENT_FEED: this.nonPersonaOrFeaturedContentFeedAlgorithm.bind(this),
   };
 
   async homeTabContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
@@ -42,7 +42,7 @@ class dataSource extends ActionAlgorithm.dataSource {
     }));
   }
 
-  async nonPersonaContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
+  async nonPersonaOrFeaturedContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byContentChannelIds(channelIds)
@@ -50,7 +50,14 @@ class dataSource extends ActionAlgorithm.dataSource {
       .skip(skip)
       .get();
 
-    return items.map((item, i) => ({
+    const filteredItems = items
+      .filter((item) => item.attributeValues.personas.value === '')
+      .filter((item) => item.attributeValues.shownonHomePage.value !== 'True')
+      .filter(
+        (item) => item.attributeValues.featuredonHomePage.value !== 'True'
+      );
+
+    return filteredItems.map((item, i) => ({
       id: `${item.id}${i}`,
       title: item.title,
       subtitle: get(item, 'contentChannel.name'),

--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -7,6 +7,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     HOME_TAB_CONTENT_FEED: this.homeTabContentFeedAlgorithm.bind(this),
+    NON_PERSONA_CONTENT_FEED: this.nonPersonaContentFeedAlgorithm.bind(this),
   };
 
   async homeTabContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
@@ -31,6 +32,25 @@ class dataSource extends ActionAlgorithm.dataSource {
     );
 
     return combinedFeaturedAndShownItems.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: get(item, 'contentChannel.name'),
+      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
+      image: ContentItem.getCoverImage(item),
+      action: 'READ_CONTENT',
+      summary: ContentItem.createSummary(item),
+    }));
+  }
+
+  async nonPersonaContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    const items = await ContentItem.byContentChannelIds(channelIds)
+      .top(limit)
+      .skip(skip)
+      .get();
+
+    return items.map((item, i) => ({
       id: `${item.id}${i}`,
       title: item.title,
       subtitle: get(item, 'contentChannel.name'),

--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -63,6 +63,7 @@ class dataSource extends ActionAlgorithm.dataSource {
       (item) => item.entityId
     );
 
+    // Returns the content items based on their EntityIds
     const filteredItems = await ContentItem.getFromIds(filteredEntityIds)
       .top(limit)
       .skip(skip)


### PR DESCRIPTION
This adjusts another content feed on the home tab. This adjustment ensures that featured items and persona feed items above this feed are not duplicated. 

Feeds are as such after this PR:
1. Latest Sermon
2. Persona Feed
3. Featured and Shown on Home Tab Feed
4. Non Persona/Featured/Shown on Home Tab Feed

This video shows that there are no duplicates. Also, tested this primarily by counting the expected number of items via filtering, and confirming the expected numbers in rock.

https://user-images.githubusercontent.com/72768221/139501017-824d973c-80a0-4ec6-b247-755b176f535e.mp4


