### PR TITLE
Fix mailto Links

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -547,20 +547,20 @@ class dataSource extends ContentItem.dataSource {
       allowedTags: false,
       allowedAttributes: false,
       transformTags: {
-        a: (tagName, { href, ...attribs }) => ({
-          tagName,
-          attribs: {
-            // adds Rock URL in the case of local urls
-            ...(href
-              ? {
-                  href: href.startsWith('http')
-                    ? href
-                    : `https://longhollow.com${href}`,
-                }
-              : {}),
-            ...attribs,
-          },
-        }),
+        a: (tagName, { href, ...attribs }) => {
+          let _href = href;
+          if (!_href.startsWith('mailto') && !_href.startsWith('http')) {
+            _href = `https://longhollow.com${href}`;
+          }
+          return {
+            tagName,
+            attribs: {
+              // adds Rock URL in the case of local urls
+              ...(href ? { href: _href } : {}),
+              ...attribs,
+            },
+          };
+        },
         img: (tagName, { src, ...attribs }) => ({
           tagName,
           attribs: {


### PR DESCRIPTION
No idea how I missed this earlier, but a simple fix to allow mailto links in the `createHTMLContent` anchor tags.

Can test by going to `/weekday-preschool` and scrolling to the bottom of the content. The email address should be a mailto link.