### PR TITLE
fix: updated home tab logic to remove redundancies

### DIFF
--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -7,10 +7,16 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     HOME_TAB_CONTENT_FEED: this.homeTabContentFeedAlgorithm.bind(this),
-    NON_PERSONA_OR_FEATURED_CONTENT_FEED: this.nonPersonaOrFeaturedContentFeedAlgorithm.bind(this),
+    NON_PERSONA_OR_FEATURED_CONTENT_FEED: this.nonPersonaOrFeaturedContentFeedAlgorithm.bind(
+      this
+    ),
   };
 
-  async homeTabContentFeedAlgorithm({ channelIds = [], limit = 40, skip = 0 } = {}) {
+  async homeTabContentFeedAlgorithm({
+    channelIds = [],
+    limit = 40,
+    skip = 0,
+  } = {}) {
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byContentChannelIds(channelIds)
@@ -42,14 +48,19 @@ class dataSource extends ActionAlgorithm.dataSource {
     }));
   }
 
-  async nonPersonaOrFeaturedContentFeedAlgorithm({ channelIds = [], limit = 10, skip = 0 } = {}) {
+  async nonPersonaOrFeaturedContentFeedAlgorithm({
+    limit = 10,
+    skip = 0,
+  } = {}) {
     // Attribute IDs
     // Persona  - 13494
     // Shown on Home Page - 12961
     // Featured on Home Page - 12962
     const { ContentItem } = this.context.dataSources;
 
-    // Returns an array of items that do not have a Persona, shownOnHomePage, or featuredOnHomePage
+    // Returns an array of items that do not have a Persona, or have False for shownOnHomePage or featuredOnHomePage
+    // This does not fully filter out items that are shown or featured on Home page, as they will have False for the
+    // opposing attribute. They will be further filtered below.
     const combinedArrayByAttribute = await this.request('AttributeValues')
       .filter(
         `
@@ -70,7 +81,17 @@ class dataSource extends ActionAlgorithm.dataSource {
       .cache({ ttl: 60 })
       .get();
 
-    return filteredItems.map((item, i) => ({
+    // This filter ensures that the remaining items are False for shownOnHomePage and featuredOnHomePage
+    // There will be *at most* 3 items here that will need to be removed and
+    // the filteredItems array will be limited in size due to the above Rock filtering.
+    // This is reverse logic of the homeTabContentFeedAlgorithm above.
+    const nonPersonaOrHomePageItems = filteredItems.filter(
+      (item) =>
+        item.attributeValues.shownonHomePage.value === 'False' &&
+        item.attributeValues.featuredonHomePage.value === 'False'
+    );
+
+    return nonPersonaOrHomePageItems.map((item, i) => ({
       id: `${item.id}${i}`,
       title: item.title,
       subtitle: get(item, 'contentChannel.name'),


### PR DESCRIPTION
This PR addresses a bug where featured items were not being completely filtered out and were appearing twice in the content feed, and brings us closer to parity between the app and website.

Before:
https://user-images.githubusercontent.com/72768221/143089991-96bb9ffc-7214-410b-9947-2e00cda8a839.mp4

After:
https://user-images.githubusercontent.com/72768221/143090067-e14b347c-e586-4053-b161-e624da43e6c2.mp4



