### PR TITLE
Update Sort for ContentItem and CTA Links

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -577,6 +577,14 @@ class dataSource extends ContentItem.dataSource {
         }),
       },
     });
+
+  byContentChannelId = (id) =>
+    this.request()
+      .filter(`ContentChannelId eq ${id}`)
+      .andFilter(this.LIVE_CONTENT())
+      .cache({ ttl: 60 })
+      .orderBy()
+      .sort(this.DEFAULT_SORT());
 }
 
 const resolver = {
@@ -734,11 +742,14 @@ const resolver = {
     ) => Matrix.getItemsFromGuid(relatedLinks?.value),
     linkText: ({ attributeValues: { linkText } }) => linkText?.value,
     linkURL: ({ attributeValues: { linkUrl } }) => linkUrl?.value,
-    ctaLinks: (
+    ctaLinks: async (
       { attributeValues: { ctaLinks } },
       args,
       { dataSources: { Matrix } }
-    ) => Matrix.getItemsFromGuid(ctaLinks?.value),
+    ) => {
+      const links = await Matrix.getItemsFromGuid(ctaLinks?.value);
+      return links.sort((a, b) => a.order - b.order);
+    },
     location: ({ attributeValues: { locationName, locationAddress } }) => ({
       name: locationName?.value,
       address: locationAddress?.valueFormatted,


### PR DESCRIPTION
**NOTE** I'm not sure if this will affect the app.

This adds a sort for content items retrieved from a content channel query.
It also sorts ctaLinks by `order` field.

For testing, compare local to prod, as well as the sort orders for some content channels:
eg Bottom of the page for `/online-giving` and `/watch`