### PR TITLE
Emit Rock metrics via Apollo plugin

### DIFF
--- a/src/apollos/rock-apollo-data-source/index.js
+++ b/src/apollos/rock-apollo-data-source/index.js
@@ -11,7 +11,6 @@ import RequestBuilder from './request-builder.js';
 const { get, mapKeys, mapValues, camelCase } = lodash;
 
 export {
-  RockLoggingExtension,
   RockRequestMetricsPlugin,
   parseKeyValueAttribute,
 } from './utils.js';

--- a/src/apollos/rock-apollo-data-source/index.js
+++ b/src/apollos/rock-apollo-data-source/index.js
@@ -10,7 +10,11 @@ import { createCursor, parseCursor } from './cursor.js';
 import RequestBuilder from './request-builder.js';
 const { get, mapKeys, mapValues, camelCase } = lodash;
 
-export { RockLoggingExtension, parseKeyValueAttribute } from './utils.js';
+export {
+  RockLoggingExtension,
+  RockRequestMetricsPlugin,
+  parseKeyValueAttribute,
+} from './utils.js';
 
 const { ROCK } = ApollosConfig;
 

--- a/src/apollos/rock-apollo-data-source/utils.js
+++ b/src/apollos/rock-apollo-data-source/utils.js
@@ -96,17 +96,3 @@ export const RockRequestMetricsPlugin = {
     };
   },
 };
-
-export class RockLoggingExtension {
-  // eslint-disable-next-line class-methods-use-this
-  willSendResponse({
-    context,
-    graphqlResponse: { data },
-  }) {
-    logRockRequestMetrics({
-      dataSources: context?.dataSources,
-      data,
-      context,
-    });
-  }
-}

--- a/src/apollos/rock-apollo-data-source/utils.js
+++ b/src/apollos/rock-apollo-data-source/utils.js
@@ -15,62 +15,98 @@ export const parseKeyValueAttribute = (text = '') => {
   });
 };
 
-export class RockLoggingExtension {
-  // eslint-disable-next-line class-methods-use-this
-  willSendResponse({
-    context: { dataSources: respDataSources },
-    graphqlResponse: { data },
-  }) {
-    let totalNetworkCalls = 0;
-    const calls = {};
-    Object.values(respDataSources).forEach((ds) => {
-      if (ds.callCount) {
-        totalNetworkCalls += ds.callCount;
-      }
-      if (ds.calls) {
-        Object.keys(ds.calls).forEach((callPath) => {
-          if (!calls[callPath]) {
-            calls[callPath] = 0;
-          }
-          calls[callPath] += ds.calls[callPath];
-        });
-      }
-    });
-    const callTable = Object.keys(calls)
-      .map((callPath) => `${decodeURI(callPath)}: ${calls[callPath]}`)
-      .join('\n');
-    const queryName = data ? Object.keys(data)[0] : null;
-    const metricsEnabled = process.env.ROCK_REQUEST_METRICS === 'true';
+export const collectRockRequestMetrics = ({ dataSources = {}, data } = {}) => {
+  let totalNetworkCalls = 0;
+  const calls = {};
+  Object.values(dataSources || {}).forEach((ds) => {
+    if (ds.callCount) {
+      totalNetworkCalls += ds.callCount;
+    }
+    if (ds.calls) {
+      Object.keys(ds.calls).forEach((callPath) => {
+        if (!calls[callPath]) {
+          calls[callPath] = 0;
+        }
+        calls[callPath] += ds.calls[callPath];
+      });
+    }
+  });
+  const callTable = Object.keys(calls)
+    .map((callPath) => `${decodeURI(callPath)}: ${calls[callPath]}`)
+    .join('\n');
+  const queryName = data ? Object.keys(data)[0] : null;
 
-    if (metricsEnabled) {
+  return { totalNetworkCalls, calls, callTable, queryName };
+};
+
+export const logRockRequestMetrics = ({
+  dataSources,
+  data,
+  context,
+} = {}) => {
+  if (context && context.__rockMetricsLogged) return;
+  if (context) context.__rockMetricsLogged = true;
+
+  const { totalNetworkCalls, calls, callTable, queryName } =
+    collectRockRequestMetrics({ dataSources, data });
+  const metricsEnabled = process.env.ROCK_REQUEST_METRICS === 'true';
+
+  if (metricsEnabled) {
+    logOutput(
+      JSON.stringify({
+        type: 'rock_request_metrics',
+        queryName,
+        totalNetworkCalls,
+        calls,
+      })
+    );
+    Object.keys(calls || {}).forEach((callPath) => {
       logOutput(
         JSON.stringify({
-          type: 'rock_request_metrics',
+          type: 'rock_request_metrics_path',
           queryName,
-          totalNetworkCalls,
-          calls,
+          path: decodeURI(callPath),
+          count: calls[callPath],
         })
       );
-      Object.keys(calls || {}).forEach((callPath) => {
-        logOutput(
-          JSON.stringify({
-            type: 'rock_request_metrics_path',
-            queryName,
-            path: decodeURI(callPath),
-            count: calls[callPath],
-          })
-        );
-      });
-      return;
-    }
+    });
+    return;
+  }
 
-    if (calls && data) {
-      logOutput(
-        `While running query: ${queryName}
+  if (calls && data) {
+    logOutput(
+      `While running query: ${queryName}
       Total Network Calls: ${totalNetworkCalls}
       ${callTable}
       `
-      );
-    }
+    );
+  }
+};
+
+export const RockRequestMetricsPlugin = {
+  requestDidStart() {
+    return {
+      willSendResponse(requestContext) {
+        logRockRequestMetrics({
+          dataSources: requestContext.context?.dataSources,
+          data: requestContext.response?.data,
+          context: requestContext.context,
+        });
+      },
+    };
+  },
+};
+
+export class RockLoggingExtension {
+  // eslint-disable-next-line class-methods-use-this
+  willSendResponse({
+    context,
+    graphqlResponse: { data },
+  }) {
+    logRockRequestMetrics({
+      dataSources: context?.dataSources,
+      data,
+      context,
+    });
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,7 @@
 import { ApolloServer } from 'apollo-server-express';
 import ApollosConfig from './apollos/config/index.js';
 import express from 'express';
-import {
-  RockLoggingExtension,
-  RockRequestMetricsPlugin,
-} from './apollos/rock-apollo-data-source/index.js';
+import { RockRequestMetricsPlugin } from './apollos/rock-apollo-data-source/index.js';
 import lodash from 'lodash';
 import { setupUniversalLinks } from './apollos/server-core/index.js';
 import { BugsnagPlugin } from './apollos/bugsnag/index.js';
@@ -36,7 +33,6 @@ const isDev =
 
 const enableRockMetrics =
   isDev || process.env.ROCK_REQUEST_METRICS === 'true';
-const extensions = enableRockMetrics ? [() => new RockLoggingExtension()] : [];
 const rockMetricsPlugins = enableRockMetrics ? [RockRequestMetricsPlugin] : [];
 
 const cacheOptions = isDev
@@ -55,7 +51,6 @@ const apolloServer = new ApolloServer({
   dataSources,
   context,
   introspection: true,
-  extensions,
   plugins: [
     new BugsnagPlugin(),
     ApolloServerPluginCacheControl(cacheOptions),


### PR DESCRIPTION
## Summary
- emit Rock request metrics via Apollo Server plugin
- keep legacy extension behavior and avoid double-logging
- wire plugin into server configuration

## Testing
- not run (log emission change)

<img width="1028" height="659" alt="Screenshot 2026-01-21 at 6 36 45 PM" src="https://github.com/user-attachments/assets/4ec18e9f-e4c3-44b4-bb45-929a8a44c554" />
