### PR TITLE
claude/setup-merge-queue-aefNU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
Adds the merge_group trigger so the lint and test jobs execute on the
temporary refs GitHub creates for the merge queue. Without this, the
required checks would never report on queued merges and the queue
would stall.